### PR TITLE
[WIP] Introducing fetchMiddleware

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["es2015", "es2017", "stage-2"]
+  "presets": ["env", "stage-2"]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-recompose",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A Redux utility belt for reducers and actions. Inspired by acdlite/recompose.",
   "engines": {
     "node": ">=8.8.1"

--- a/package.json
+++ b/package.json
@@ -33,8 +33,7 @@
     "fetch-mock": "^5.13.1",
     "jest": "^21.2.1",
     "redux": "^3.7.2",
-    "redux-mock-store": "^1.3.0",
-    "redux-thunk": "^2.2.0"
+    "redux-mock-store": "^1.3.0"
   },
   "dependencies": {
     "babel-preset-es2015": "^6.24.1",

--- a/package.json
+++ b/package.json
@@ -28,19 +28,18 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-jest": "^21.2.0",
+    "babel-preset-env": "^1.6.1",
+    "babel-preset-stage-2": "^6.24.1",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
     "fetch-mock": "^5.13.1",
     "jest": "^21.2.1",
     "redux": "^3.7.2",
-    "redux-mock-store": "^1.3.0"
+    "redux-mock-store": "^1.3.0",
+    "seamless-immutable": "^7.1.2",
+    "eslint": "^4.11.0"
   },
   "dependencies": {
-    "babel-preset-es2015": "^6.24.1",
-    "babel-preset-es2017": "^6.24.1",
-    "babel-preset-stage-2": "^6.24.1",
-    "eslint": "^4.11.0",
-    "seamless-immutable": "^7.1.2",
     "babel-core": "^6.26.0",
     "babel-polyfill": "^6.26.0"
   }

--- a/src/creators/createThunkAction/index.js
+++ b/src/creators/createThunkAction/index.js
@@ -1,8 +1,14 @@
 import composeInjections from '../../injections/composeInjections';
 import baseThunkAction from '../../injections/baseThunkAction';
 
-function createThunkAction(type, target, serviceCall, selector = () => {}) {
-  return composeInjections(baseThunkAction(type, target, serviceCall, selector));
+function createThunkAction(type, target, serviceCall, payload = () => {}) {
+  console.warning('redux-recompose: createThunkAction is deprecated. Use fetch middleware instead.');
+  return composeInjections(baseThunkAction({
+    type,
+    target,
+    serviceCall,
+    payload
+  }));
 }
 
 export default createThunkAction;

--- a/src/creators/createThunkAction/test.js
+++ b/src/creators/createThunkAction/test.js
@@ -13,7 +13,7 @@ const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE'], '@TEST'
 describe('createThunkAction', () => {
   it('Dispatches SUCCESS correctly', async () => {
     const store = mockStore({});
-    await store.dispatch(createThunkAction(actions.FETCH, 'aTarget', MockService.fetchSomething));
+    await store.dispatch({ type: actions.FETCH, target: 'aTarget', service: MockService.fetchSomething });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([
       { type: actions.FETCH, target: 'aTarget' },

--- a/src/creators/createThunkAction/test.js
+++ b/src/creators/createThunkAction/test.js
@@ -1,8 +1,6 @@
 import mockStore from '../../utils/asyncActionsUtils';
 import createTypes from '../createTypes';
 
-import createThunkAction from '.';
-
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
   fetchFailure: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR' }))
@@ -22,7 +20,7 @@ describe('createThunkAction', () => {
   });
   it('Dispatches FAILURE correctly', async () => {
     const store = mockStore({});
-    await store.dispatch(createThunkAction(actions.FETCH, 'aTarget', MockService.fetchFailure));
+    await store.dispatch({ type: actions.FETCH, target: 'aTarget', service: MockService.fetchFailure });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([
       { type: actions.FETCH, target: 'aTarget' },

--- a/src/creators/createTypes/index.js
+++ b/src/creators/createTypes/index.js
@@ -1,5 +1,3 @@
-import Immutable from 'seamless-immutable';
-
 /**
  * Receives an array of strings, and returns an obj with that strings as properties
    with that string as value.
@@ -10,10 +8,14 @@ function stringArrayToObject(actionsArray, namespace) {
   if (actionsArray.some(actionName => !actionName || typeof actionName !== 'string')) {
     throw new Error('Action names must be an array of strings.');
   }
-  return Immutable(actionsArray).asObject(actionName => [
-    actionName,
-    namespace ? `${namespace}/${actionName}` : actionName
-  ]);
+
+  const actionNames = {};
+
+  actionsArray.forEach(actionName => {
+    actionNames[actionName] = namespace ? `${namespace}/${actionName}` : actionName;
+  });
+
+  return actionNames;
 }
 
 function createTypes(actionsArray, namespace) {

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,8 @@ import withPostSuccess from './injections/withPostSuccess';
 import withPrefetch from './injections/withPrefetch';
 import withStatusHandling from './injections/withStatusHandling';
 
+import fetchMiddleware from './middlewares/fetch';
+
 exports.completeReducer = completeReducer;
 exports.completeState = completeState;
 exports.completeTypes = completeTypes;
@@ -52,3 +54,5 @@ exports.withPostFetch = withPostFetch;
 exports.withPostSuccess = withPostSuccess;
 exports.withPrefetch = withPrefetch;
 exports.withStatusHandling = withStatusHandling;
+
+exports.fetchMiddleware = fetchMiddleware;

--- a/src/injections/baseThunkAction/index.js
+++ b/src/injections/baseThunkAction/index.js
@@ -1,7 +1,7 @@
-function baseThunkAction(type, target, serviceMethod, selector = () => {}) {
+function baseThunkAction(type, target, service, selector = () => {}) {
   return {
     prebehavior: dispatch => dispatch({ type, target }),
-    apiCall: async getState => serviceMethod(selector(getState())),
+    apiCall: async getState => service(selector(getState())),
     determination: response => response.ok,
     success: (dispatch, response) => dispatch({ type: `${type}_SUCCESS`, target, payload: response.data }),
     failure: (dispatch, response) => dispatch({ type: `${type}_FAILURE`, target, payload: response.problem })

--- a/src/injections/baseThunkAction/index.js
+++ b/src/injections/baseThunkAction/index.js
@@ -1,4 +1,11 @@
-function baseThunkAction(type, target, service, selector = () => {}) {
+function baseThunkAction({
+  type,
+  target,
+  service,
+  payload = () => {}
+}) {
+  const selector = typeof payload === 'function' ? payload : () => payload;
+
   return {
     prebehavior: dispatch => dispatch({ type, target }),
     apiCall: async getState => service(selector(getState())),

--- a/src/injections/composeInjections/index.js
+++ b/src/injections/composeInjections/index.js
@@ -1,5 +1,7 @@
-function composeInjections(...decorators) {
-  const decoratorDescription = decorators.reduce((a, b) => ({ ...a, ...b }), {});
+import mergeInjections from '../mergeInjections';
+
+function composeInjections(...injections) {
+  const injectionsDescription = mergeInjections(injections);
 
   const {
     prebehavior = () => {},
@@ -10,7 +12,7 @@ function composeInjections(...decorators) {
     postBehavior = () => {},
     failure = () => {},
     statusHandler = () => true
-  } = decoratorDescription;
+  } = injectionsDescription;
 
   return async (dispatch, getState) => {
     prebehavior(dispatch);

--- a/src/injections/mergeInjections/index.js
+++ b/src/injections/mergeInjections/index.js
@@ -1,0 +1,5 @@
+function mergeInjections(injections) {
+  return injections.reduce((a, b) => ({ ...a, ...b }), {});
+}
+
+export default mergeInjections;

--- a/src/injections/withFlowDetermination/test.js
+++ b/src/injections/withFlowDetermination/test.js
@@ -1,7 +1,5 @@
 import mockStore from '../../utils/asyncActionsUtils';
 import createTypes from '../../creators/createTypes';
-import composeInjections from '../composeInjections';
-import baseThunkAction from '../baseThunkAction';
 
 import withFlowDetermination from '.';
 
@@ -21,20 +19,26 @@ const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_A
 describe('withFlowDetermination', () => {
   it('Handles correctly the flow determination', async () => {
     const store = mockStore({});
-    await store.dispatch(composeInjections(
-      baseThunkAction(actions.FETCH, 'aTarget', MockService.fetchSomething),
-      withFlowDetermination(response => response.ok)
-    ));
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      injections: withFlowDetermination(response => response.ok)
+    });
 
-    await store.dispatch(composeInjections(
-      baseThunkAction(actions.FETCH, 'aTarget', MockService.fetchFailureNotFound),
-      withFlowDetermination(response => response.ok)
-    ));
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailureNotFound,
+      injections: [withFlowDetermination(response => response.ok)]
+    });
 
-    await store.dispatch(composeInjections(
-      baseThunkAction(actions.FETCH, 'aTarget', MockService.fetchFailureNotFound),
-      withFlowDetermination(response => response.status === 404)
-    ));
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailureNotFound,
+      injections: withFlowDetermination(response => response.status === 404)
+    });
 
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([

--- a/src/injections/withPostFetch/test.js
+++ b/src/injections/withPostFetch/test.js
@@ -1,7 +1,5 @@
 import mockStore from '../../utils/asyncActionsUtils';
 import createTypes from '../../creators/createTypes';
-import composeInjections from '../composeInjections';
-import baseThunkAction from '../baseThunkAction';
 
 import withPostFetch from '.';
 
@@ -15,11 +13,13 @@ const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'FETCH_L
 describe('withPostFetch', () => {
   it('Handles correctly the post fetch behavior', async () => {
     const store = mockStore({});
-    await store.dispatch(composeInjections(
-      baseThunkAction(actions.FETCH, 'aTarget', MockService.fetchSomething),
-      withPostFetch((dispatch, response) =>
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      injections: withPostFetch((dispatch, response) =>
         dispatch({ type: actions.FETCH_LOADING, payload: response.ultraSecretData }))
-    ));
+    });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([
       { type: actions.FETCH, target: 'aTarget' },

--- a/src/injections/withPostSuccess/test.js
+++ b/src/injections/withPostSuccess/test.js
@@ -1,7 +1,5 @@
 import mockStore from '../../utils/asyncActionsUtils';
 import createTypes from '../../creators/createTypes';
-import composeInjections from '../composeInjections';
-import baseThunkAction from '../baseThunkAction';
 
 import withPostSuccess from '.';
 
@@ -15,10 +13,13 @@ const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_A
 describe('withPostSuccess', () => {
   it('Handles correctly post success', async () => {
     const store = mockStore({});
-    await store.dispatch(composeInjections(
-      baseThunkAction(actions.FETCH, 'aTarget', MockService.fetchSomething),
-      withPostSuccess(dispatch => dispatch({ type: actions.OTHER_ACTION }))
-    ));
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      injections: withPostSuccess(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+    });
+
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([
       { type: actions.FETCH, target: 'aTarget' },

--- a/src/injections/withPrefetch/test.js
+++ b/src/injections/withPrefetch/test.js
@@ -1,7 +1,5 @@
 import mockStore from '../../utils/asyncActionsUtils';
 import createTypes from '../../creators/createTypes';
-import composeInjections from '../composeInjections';
-import baseThunkAction from '../baseThunkAction';
 
 import withPreFetch from '.';
 
@@ -15,10 +13,12 @@ const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'FETCH_L
 describe('withPreFetch', () => {
   it('Handles correctly the prefetch behavior', async () => {
     const store = mockStore({});
-    await store.dispatch(composeInjections(
-      baseThunkAction(actions.FETCH, 'aTarget', MockService.fetchSomething),
-      withPreFetch(dispatch => dispatch({ type: actions.FETCH_LOADING }))
-    ));
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      injections: withPreFetch(dispatch => dispatch({ type: actions.FETCH_LOADING }))
+    });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([
       { type: actions.FETCH_LOADING },

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -1,0 +1,21 @@
+import baseThunkAction from '../injections/baseThunkAction';
+import composeInjections from '../injections/composeInjections';
+import mergeInjections from '../injections/mergeInjections';
+
+const ensembleInjections = action => {
+  const base = baseThunkAction(action);
+  if (!action.injections) return base;
+
+  const injections = action.injections.constructor === Array
+    ? mergeInjections(action.injections) : action.injections;
+
+  return { ...base, ...injections };
+};
+
+const fetchMiddleware = ({ dispatch }) => next => action => (
+  action.service ?
+    dispatch(composeInjections(ensembleInjections(action))) :
+    next(action)
+);
+
+export default fetchMiddleware;

--- a/src/utils/asyncActionsUtils.js
+++ b/src/utils/asyncActionsUtils.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import configureMockStore from 'redux-mock-store';
 
-import createThunkAction from '../creators/createThunkAction';
+import fetchMiddleware from '../middlewares/fetch';
 
 const thunk = ({ dispatch, getState }) => next => action => (
   typeof action === 'function' ?
@@ -9,13 +9,7 @@ const thunk = ({ dispatch, getState }) => next => action => (
     next(action)
 );
 
-const fetchMiddleware = ({ dispatch }) => next => action => (
-  action.service !== undefined ?
-    dispatch(createThunkAction(action.type, action.target, action.service, action.selector)) :
-    next(action)
-);
-
-const middlewares = [thunk, fetchMiddleware];
+const middlewares = [fetchMiddleware, thunk];
 const mockStore = configureMockStore(middlewares);
 
 export default mockStore;

--- a/src/utils/asyncActionsUtils.js
+++ b/src/utils/asyncActionsUtils.js
@@ -1,8 +1,21 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import configureMockStore from 'redux-mock-store';
-import thunk from 'redux-thunk';
 
-const middlewares = [thunk];
+import createThunkAction from '../creators/createThunkAction';
+
+const thunk = ({ dispatch, getState }) => next => action => (
+  typeof action === 'function' ?
+    action(dispatch, getState) :
+    next(action)
+);
+
+const fetchMiddleware = ({ dispatch }) => next => action => (
+  action.service !== undefined ?
+    dispatch(createThunkAction(action.type, action.target, action.service, action.selector)) :
+    next(action)
+);
+
+const middlewares = [thunk, fetchMiddleware];
 const mockStore = configureMockStore(middlewares);
 
 export default mockStore;


### PR DESCRIPTION
## Summary

* Introduces `fetchMiddleware`: `composeInjections` is no longer needed to be exported. Async actions now can be described as plain objects:
```
const fetchBooks = id => ({
  type: actions.FETCH,
  target: 'books',
  payload: id,
  service: Service.getBooks,
  injections: withStatusHandling({ 404: () => console.log('Not found') })
})
```
is equivalent to:
```
const fetchBooks = id => async dispatch => {
  dispatch({ type: actions.FETCH });
  const response = await Service.getBooks(id);
  if (response.ok) {
    dispatch({ type: actions.FETCH_SUCCESS, payload: response.data });
  } else {
    if (response.status === 404) console.log('Not found');
    dispatch({ type: actions.FETCH_FAILURE, payload: response.problem });
  }
}
```
Just:
```
import { fetchMiddleware } from 'redux-recompose';
```
and include it as a middleware along with `redux-thunk`.
* Deprecates `createThunkAction` in favor of using plain objects.
* Removed `seamless-immutable` dependency, `redux-thunk` dev dependency.
* Updating babel-presets to use `env` and including `babel-polyfill` as dependence.
* Tested with `jest` for functionalities and with `react-scripts build` for compilation :sunglasses: 

## Known Issues
* Missing documentation :shame: Coming soon.
* `fetchMiddleware` does not work if `thunk` is not configured.