### PR TITLE
Adding support for modal actions and single called

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["env", "stage-2"]
+  "presets": ["env", "stage-2"],
+  "plugins": ["transform-runtime"]
 }

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+src/index.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+package-lock.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 src/
+.babelrc

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-recompose",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "A Redux utility belt for reducers and actions. Inspired by acdlite/recompose.",
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-recompose",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "A Redux utility belt for reducers and actions. Inspired by acdlite/recompose.",
   "engines": {
     "node": ">=6.0.0"

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest",
     "compile": "babel -d lib/ src/",
-    "prepublishOnlynp": "npm run compile"
+    "prepublishOnly": "npm run compile"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "redux-recompose",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "A Redux utility belt for reducers and actions. Inspired by acdlite/recompose.",
   "engines": {
-    "node": ">=8.8.1"
+    "node": ">=6.0.0"
   },
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-recompose",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A Redux utility belt for reducers and actions. Inspired by acdlite/recompose.",
   "engines": {
     "node": ">=8.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-recompose",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "A Redux utility belt for reducers and actions. Inspired by acdlite/recompose.",
   "engines": {
     "node": ">=6.0.0"
@@ -9,7 +9,7 @@
   "scripts": {
     "test": "jest",
     "compile": "babel -d lib/ src/",
-    "prepublish": "npm run compile"
+    "prepublishOnlynp": "npm run compile"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -28,19 +28,16 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-jest": "^21.2.0",
+    "babel-plugin-transform-runtime": "^6.23.0",
     "babel-preset-env": "^1.6.1",
     "babel-preset-stage-2": "^6.24.1",
+    "eslint": "^4.11.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",
     "fetch-mock": "^5.13.1",
     "jest": "^21.2.1",
     "redux": "^3.7.2",
     "redux-mock-store": "^1.3.0",
-    "seamless-immutable": "^7.1.2",
-    "eslint": "^4.11.0"
-  },
-  "dependencies": {
-    "babel-core": "^6.26.0",
-    "babel-polyfill": "^6.26.0"
+    "seamless-immutable": "^7.1.2"
   }
 }

--- a/src/completers/completeReducer/index.js
+++ b/src/completers/completeReducer/index.js
@@ -1,26 +1,44 @@
 import onLoading from '../../effects/onLoading';
 import onSuccess from '../../effects/onSuccess';
 import onFailure from '../../effects/onFailure';
+
+import onSubscribe from '../../effects/onSubscribe';
+import onUnsubscribe from '../../effects/onUnsubscribe';
+
 import { isStringArray, isValidObject } from '../../utils/typeUtils';
 
 // Given a reducer description, it returns a reducerHandler with all success and failure cases
 function completeReducer(reducerDescription) {
   if (
     !reducerDescription ||
-    !reducerDescription.primaryActions ||
-    !reducerDescription.primaryActions.length
+    ((!reducerDescription.primaryActions || !reducerDescription.primaryActions.length) &&
+    (!reducerDescription.modalActions || !reducerDescription.modalActions.length))
   ) {
-    throw new Error('Reducer description is incomplete, should contain at least a primaryActions field');
+    throw new Error('Reducer description is incomplete, should contain at least an actions field to complete');
   }
-  if (!isStringArray(reducerDescription.primaryActions)) {
-    throw new Error('Primary actions must be a string array');
-  }
+
   let reducerHandler = {};
-  reducerDescription.primaryActions.forEach(actionName => {
-    reducerHandler[actionName] = onLoading();
-    reducerHandler[`${actionName}_SUCCESS`] = onSuccess();
-    reducerHandler[`${actionName}_FAILURE`] = onFailure();
-  });
+
+  if (reducerDescription.primaryActions) {
+    if (!isStringArray(reducerDescription.primaryActions)) {
+      throw new Error('Primary actions must be a string array');
+    }
+    reducerDescription.primaryActions.forEach(actionName => {
+      reducerHandler[actionName] = onLoading();
+      reducerHandler[`${actionName}_SUCCESS`] = onSuccess();
+      reducerHandler[`${actionName}_FAILURE`] = onFailure();
+    });
+  }
+
+  if (reducerDescription.modalActions) {
+    if (!isStringArray(reducerDescription.modalActions)) {
+      throw new Error('Modal actions must be a string array');
+    }
+    reducerDescription.modalActions.forEach(actionName => {
+      reducerHandler[`${actionName}_OPEN`] = onSubscribe();
+      reducerHandler[`${actionName}_CLOSE`] = onUnsubscribe();
+    });
+  }
 
   if (reducerDescription.override) {
     if (!isValidObject(reducerDescription.override)) {

--- a/src/completers/completeReducer/test.js
+++ b/src/completers/completeReducer/test.js
@@ -1,6 +1,7 @@
 import Immutable from 'seamless-immutable';
 
 import createReducer from '../../creators/createReducer';
+import createModalActions from '../../creators/createModalActions';
 import onFailure from '../../effects/onFailure';
 
 import completeReducer from '.';
@@ -8,7 +9,9 @@ import completeReducer from '.';
 const initialState = {
   target: 1,
   targetLoading: false,
-  targetError: null
+  targetError: null,
+  modalIsOpen: false,
+  modalContent: null
 };
 
 const setUp = {
@@ -75,5 +78,18 @@ describe('completeReducer', () => {
     setUp.state = reducer(setUp.state, { type: '@NAMESPACE/ANOTHER', target: 'target', payload: 'Also known as Ermac' });
     expect(setUp.state.targetError).toBe('Also known as Ermac');
     // Flawless victory
+  });
+  it('Completes modal actions', () => {
+    const reducerDescription = {
+      modalActions: ['@NAMESPACE/MODAL']
+    };
+    const reducer = createReducer(setUp.state, completeReducer(reducerDescription));
+    const modal = createModalActions({ type: '@NAMESPACE/MODAL', target: 'modalIsOpen', contentTarget: 'modalContent' });
+    setUp.state = reducer(setUp.state, modal.open('Title'));
+    expect(setUp.state.modalIsOpen).toBe(true);
+    expect(setUp.state.modalContent).toBe('Title');
+    setUp.state = reducer(setUp.state, modal.close());
+    expect(setUp.state.modalIsOpen).toBe(false);
+    expect(setUp.state.modalContent).toBe(null);
   });
 });

--- a/src/creators/createModalActions/index.js
+++ b/src/creators/createModalActions/index.js
@@ -1,0 +1,8 @@
+function createModalActions({ type, target, contentTarget }) {
+  return {
+    open: modalContent => ({ type: `${type}_OPEN`, target, payload: { [contentTarget]: modalContent } }),
+    close: (emptyModalContent = null) => ({ type: `${type}_CLOSE`, target, payload: { [contentTarget]: emptyModalContent } })
+  };
+}
+
+export default createModalActions;

--- a/src/effects/onSubscribe/index.js
+++ b/src/effects/onSubscribe/index.js
@@ -1,0 +1,6 @@
+// TODO: Add validations for multitargeted actions
+function onSubscribe(selector = action => action.payload) {
+  return (state, action) => state.merge({ [action.target]: true, ...selector(action) });
+}
+
+export default onSubscribe;

--- a/src/effects/onUnsubscribe/index.js
+++ b/src/effects/onUnsubscribe/index.js
@@ -1,0 +1,6 @@
+// TODO: Add validations for multitargeted actions
+function onUnsubscribe(selector = action => action.payload) {
+  return (state, action) => state.merge({ [action.target]: false, ...selector(action) });
+}
+
+export default onUnsubscribe;

--- a/src/index.js
+++ b/src/index.js
@@ -26,6 +26,7 @@ import withPostFetch from './injections/withPostFetch';
 import withPostSuccess from './injections/withPostSuccess';
 import withPrefetch from './injections/withPrefetch';
 import withStatusHandling from './injections/withStatusHandling';
+import withSuccess from './injections/withSuccess';
 
 import fetchMiddleware from './middlewares/fetch';
 
@@ -54,5 +55,6 @@ exports.withPostFetch = withPostFetch;
 exports.withPostSuccess = withPostSuccess;
 exports.withPrefetch = withPrefetch;
 exports.withStatusHandling = withStatusHandling;
+exports.withSuccess = withSuccess;
 
 exports.fetchMiddleware = fetchMiddleware;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
-import 'babel-core/register';
-import 'babel-polyfill';
+try {
+  require('babel-polyfill');
+} catch (e) {};
 
 import completeReducer from './completers/completeReducer';
 import completeState from './completers/completeState';

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ import completeTypes from './completers/completeTypes';
 
 import createReducer from './creators/createReducer';
 import createTypes from './creators/createTypes';
+import createModalActions from './creators/createModalActions';
 import createThunkAction from './creators/createThunkAction';
 
 import onDelete from './effects/onDelete';
@@ -17,6 +18,8 @@ import onLoading from './effects/onLoading';
 import onReadValue from './effects/onReadValue';
 import onSetValue from './effects/onSetValue';
 import onSuccess from './effects/onSuccess';
+import onSubscribe from './effects/onSubscribe';
+import onUnsubscribe from './effects/onUnsubscribe';
 
 import baseThunkAction from './injections/baseThunkAction';
 import composeInjections from './injections/composeInjections';
@@ -37,6 +40,7 @@ exports.completeTypes = completeTypes;
 exports.createReducer = createReducer;
 exports.createTypes = createTypes;
 exports.createThunkAction = createThunkAction;
+exports.createModalActions = createModalActions;
 
 exports.onDelete = onDelete;
 exports.onDeleteByIndex = onDeleteByIndex;
@@ -46,6 +50,8 @@ exports.onLoading = onLoading;
 exports.onReadValue = onReadValue;
 exports.onSetValue = onSetValue;
 exports.onSuccess = onSuccess;
+exports.onSubscribe = onSubscribe;
+exports.onUnsubscribe = onUnsubscribe;
 
 exports.baseThunkAction = baseThunkAction;
 exports.composeInjections = composeInjections;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,3 @@
-try {
-  require('babel-polyfill');
-} catch (e) {};
-
 import completeReducer from './completers/completeReducer';
 import completeState from './completers/completeState';
 import completeTypes from './completers/completeTypes';

--- a/src/injections/composeInjections/index.js
+++ b/src/injections/composeInjections/index.js
@@ -19,11 +19,11 @@ function composeInjections(...injections) {
     const response = await apiCall(getState);
     postBehavior(dispatch, response);
     if (determination(response)) {
-      const shouldContinue = success(dispatch, response);
-      if (shouldContinue) postSuccess(dispatch, response);
+      const shouldContinue = success(dispatch, response, getState());
+      if (shouldContinue) postSuccess(dispatch, response, getState());
     } else {
-      const shouldContinue = statusHandler(dispatch, response);
-      if (shouldContinue) failure(dispatch, response);
+      const shouldContinue = statusHandler(dispatch, response, getState());
+      if (shouldContinue) failure(dispatch, response, getState());
     }
   };
 }

--- a/src/injections/composeInjections/index.js
+++ b/src/injections/composeInjections/index.js
@@ -7,7 +7,7 @@ function composeInjections(...injections) {
     prebehavior = () => {},
     apiCall = () => {},
     determination = () => true,
-    success = () => {},
+    success = () => true,
     postSuccess = () => {},
     postBehavior = () => {},
     failure = () => {},

--- a/src/injections/emptyThunkAction/index.js
+++ b/src/injections/emptyThunkAction/index.js
@@ -1,0 +1,11 @@
+function emptyThunkAction({ type, service, payload = () => {} }) {
+  const selector = typeof payload === 'function' ? payload : () => payload;
+
+  return {
+    prebehavior: dispatch => dispatch({ type }),
+    apiCall: async getState => service(selector(getState())),
+    determination: response => response.ok
+  };
+}
+
+export default emptyThunkAction;

--- a/src/injections/emptyThunkAction/test.js
+++ b/src/injections/emptyThunkAction/test.js
@@ -1,0 +1,37 @@
+import mockStore from '../../utils/asyncActionsUtils';
+import createTypes from '../../creators/createTypes';
+import withPostSuccess from '../withPostSuccess';
+
+const MockService = {
+  fetchSomething: async (data = 42) =>
+    new Promise(resolve => resolve({ ok: true, data: data + 1 })),
+  fetchFailure: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR' }))
+};
+
+const actions = createTypes(['FETCH', 'OTHER_FETCH'], '@TEST');
+
+describe('emptyThunkAction', () => {
+  it('Just dispatches FETCH action if no target is specified', async () => {
+    const store = mockStore({});
+    await store.dispatch({ type: actions.FETCH, service: MockService.fetchSomething });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH }
+    ]);
+  });
+  it('Calls the service specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      service: MockService.fetchSomething,
+      payload: 20,
+      injections: withPostSuccess((dispatch, response) =>
+        dispatch({ type: actions.OTHER_FETCH, payload: response.data }))
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH },
+      { type: actions.OTHER_FETCH, payload: 21 }
+    ]);
+  });
+});

--- a/src/injections/singleCallThunkAction/index.js
+++ b/src/injections/singleCallThunkAction/index.js
@@ -1,0 +1,10 @@
+function singleCallThunkAction({ service, payload = () => {} }) {
+  const selector = typeof payload === 'function' ? payload : () => payload;
+
+  return {
+    apiCall: async getState => service(selector(getState())),
+    determination: response => response.ok
+  };
+}
+
+export default singleCallThunkAction;

--- a/src/injections/singleCallThunkAction/test.js
+++ b/src/injections/singleCallThunkAction/test.js
@@ -1,0 +1,33 @@
+import mockStore from '../../utils/asyncActionsUtils';
+import createTypes from '../../creators/createTypes';
+import withPostSuccess from '../withPostSuccess';
+
+const MockService = {
+  fetchSomething: async (data = 42) =>
+    new Promise(resolve => resolve({ ok: true, data: data + 1 })),
+  fetchFailure: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR' }))
+};
+
+const actions = createTypes(['FETCH', 'OTHER_FETCH'], '@TEST');
+
+describe('singleCallThunkAction', () => {
+  it('Does not dispatch an action by default', async () => {
+    const store = mockStore({});
+    await store.dispatch({ service: MockService.fetchSomething });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([]);
+  });
+  it('Calls the service specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      service: MockService.fetchSomething,
+      payload: 20,
+      injections: withPostSuccess((dispatch, response) =>
+        dispatch({ type: actions.OTHER_FETCH, payload: response.data }))
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.OTHER_FETCH, payload: 21 }
+    ]);
+  });
+});

--- a/src/injections/withSuccess/index.js
+++ b/src/injections/withSuccess/index.js
@@ -1,0 +1,5 @@
+function withSuccess(withSuccessBehavior) {
+  return { success: withSuccessBehavior };
+}
+
+export default withSuccess;

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -1,10 +1,16 @@
 import baseThunkAction from '../injections/baseThunkAction';
 import emptyThunkAction from '../injections/emptyThunkAction';
+import singleCallThunkAction from '../injections/singleCallThunkAction';
 import composeInjections from '../injections/composeInjections';
 import mergeInjections from '../injections/mergeInjections';
 
 const ensembleInjections = action => {
-  const base = action.target ? baseThunkAction(action) : emptyThunkAction(action);
+  let base;
+  if (!action.type) {
+    base = singleCallThunkAction(action);
+  } else {
+    base = action.target ? baseThunkAction(action) : emptyThunkAction(action);
+  }
   if (!action.injections) return base;
 
   const injections = action.injections.constructor === Array

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -1,9 +1,10 @@
 import baseThunkAction from '../injections/baseThunkAction';
+import emptyThunkAction from '../injections/emptyThunkAction';
 import composeInjections from '../injections/composeInjections';
 import mergeInjections from '../injections/mergeInjections';
 
 const ensembleInjections = action => {
-  const base = baseThunkAction(action);
+  const base = action.target ? baseThunkAction(action) : emptyThunkAction(action);
   if (!action.injections) return base;
 
   const injections = action.injections.constructor === Array


### PR DESCRIPTION
### Summary

* `fetchMiddleware` now supports actions without a `target` and even without a `type`. The first ones are called `emptyThunkAction` whereas the later ones are called `singleCallThunkAction`.
`emptyThunkActions` represent those actions that just calls a service but only an action is being dispatched.
`singleCallActions` at does not dispatch actions.
We can customize these behaviors adding injections.

* Introducing `createModalActions` creator, `onSubscribe` and `onUnsubscribe` effects.

* Defining and exporting `withSuccess` injection.
