### PR TITLE
Introduced postFailure injection

### DIFF
--- a/src/injections/composeInjections/index.js
+++ b/src/injections/composeInjections/index.js
@@ -10,6 +10,7 @@ function composeInjections(...injections) {
     success = () => {},
     postSuccess = () => {},
     postBehavior = () => {},
+    postFailure = () => {},
     failure = () => {},
     statusHandler = () => true
   } = injectionsDescription;
@@ -23,7 +24,10 @@ function composeInjections(...injections) {
       if (shouldContinue) postSuccess(dispatch, response);
     } else {
       const shouldContinue = statusHandler(dispatch, response);
-      if (shouldContinue) failure(dispatch, response);
+      if (shouldContinue) {
+        failure(dispatch, response);
+        postFailure(dispatch, response);
+      }
     }
   };
 }

--- a/src/injections/withPostFailure/index.js
+++ b/src/injections/withPostFailure/index.js
@@ -1,0 +1,7 @@
+function withPostFailure(behavior) {
+  return {
+    postFailure: behavior
+  };
+}
+
+export default withPostFailure;

--- a/src/injections/withPostFailure/test.js
+++ b/src/injections/withPostFailure/test.js
@@ -1,0 +1,47 @@
+import mockStore from '../../utils/asyncActionsUtils';
+import createTypes from '../../creators/createTypes';
+
+import withPostFailure from '.';
+
+const MockService = {
+  fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
+  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
+};
+
+const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_ACTION'], '@TEST');
+
+describe('withPostFailure', () => {
+  it('Handles correctly post failure', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailureNotFound,
+      injections: withPostFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+    });
+
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      { type: actions.FETCH_FAILURE, target: 'aTarget', payload: 'CLIENT_ERROR' },
+      { type: actions.OTHER_ACTION }
+    ]);
+  });
+
+  it('Does not dispatch on post failure in case of success', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      injections: withPostFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+    });
+
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      { type: actions.FETCH_SUCCESS, target: 'aTarget', payload: 42 }
+    ]);
+  });
+});
+


### PR DESCRIPTION
## Summary

Added `withPostFailure` injection that executes after `failure`. Also, added their corresponding tests