### PR TITLE
Added parameters to handle responses

### DIFF
--- a/src/injections/baseThunkAction/index.js
+++ b/src/injections/baseThunkAction/index.js
@@ -2,7 +2,9 @@ function baseThunkAction({
   type,
   target,
   service,
-  payload = () => {}
+  payload = () => {},
+  successData = response => response.data,
+  failureData = response => response.problem
 }) {
   const selector = typeof payload === 'function' ? payload : () => payload;
 
@@ -10,8 +12,8 @@ function baseThunkAction({
     prebehavior: dispatch => dispatch({ type, target }),
     apiCall: async getState => service(selector(getState())),
     determination: response => response.ok,
-    success: (dispatch, response) => dispatch({ type: `${type}_SUCCESS`, target, payload: response.data }),
-    failure: (dispatch, response) => dispatch({ type: `${type}_FAILURE`, target, payload: response.problem })
+    success: (dispatch, response) => dispatch({ type: `${type}_SUCCESS`, target, payload: successData(response) }),
+    failure: (dispatch, response) => dispatch({ type: `${type}_FAILURE`, target, payload: failureData(response) })
   };
 }
 

--- a/src/injections/baseThunkAction/index.js
+++ b/src/injections/baseThunkAction/index.js
@@ -3,8 +3,8 @@ function baseThunkAction({
   target,
   service,
   payload = () => {},
-  successData = response => response.data,
-  failureData = response => response.problem
+  successSelector = response => response.data,
+  failureSelector = response => response.problem
 }) {
   const selector = typeof payload === 'function' ? payload : () => payload;
 
@@ -12,8 +12,8 @@ function baseThunkAction({
     prebehavior: dispatch => dispatch({ type, target }),
     apiCall: async getState => service(selector(getState())),
     determination: response => response.ok,
-    success: (dispatch, response) => dispatch({ type: `${type}_SUCCESS`, target, payload: successData(response) }),
-    failure: (dispatch, response) => dispatch({ type: `${type}_FAILURE`, target, payload: failureData(response) })
+    success: (dispatch, response) => dispatch({ type: `${type}_SUCCESS`, target, payload: successSelector(response) }),
+    failure: (dispatch, response) => dispatch({ type: `${type}_FAILURE`, target, payload: failureSelector(response) })
   };
 }
 

--- a/src/injections/baseThunkAction/test.js
+++ b/src/injections/baseThunkAction/test.js
@@ -1,0 +1,69 @@
+import mockStore from '../../utils/asyncActionsUtils';
+import createTypes from '../../creators/createTypes';
+
+const MockService = {
+  fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 30 })),
+  fetchSomethingForSelector: async () => new Promise(resolve => resolve({ ok: true, newData: 40 })),
+  fetchFailure: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR' })),
+  fetchFailureForSelector: async () => new Promise(resolve => resolve({ ok: false, error: 'NEW_CLIENT_ERROR' }))
+};
+
+const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_FETCH'], '@TEST');
+
+describe('baseThunkAction', () => {
+  it('Uses the default success selector if not specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      { type: actions.FETCH_SUCCESS, target: 'aTarget', payload: 30 }
+    ]);
+  });
+  it('Uses success selector specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomethingForSelector,
+      successSelector: response => response.newData
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      { type: actions.FETCH_SUCCESS, target: 'aTarget', payload: 40 }
+    ]);
+  });
+
+  it('Uses the default failure selector if not specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailure
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      { type: actions.FETCH_FAILURE, target: 'aTarget', payload: 'CLIENT_ERROR' }
+    ]);
+  });
+  it('Uses success selector specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailureForSelector,
+      failureSelector: response => response.error
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      { type: actions.FETCH_FAILURE, target: 'aTarget', payload: 'NEW_CLIENT_ERROR' }
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Added `successData` and `failureData` functions to handle success and failure payload. As default, it uses `response.data` and `response.problem`, but the user could define its own handlers from outside.

Also, all tests run OK 😎 

@mvbattan what do you think of the handler names? should I change them?