### PR TITLE
Stop compiling tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,4 @@
 {
   "presets": ["env", "stage-2"],
-  "plugins": ["transform-runtime"],
-  "ignore": ["**/test.js"]
+  "plugins": ["transform-runtime"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,5 @@
 {
   "presets": ["env", "stage-2"],
-  "plugins": ["transform-runtime"]
+  "plugins": ["transform-runtime"],
+  "ignore": ["**/test.js"]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "lib/index.js",
   "scripts": {
     "test": "jest",
-    "compile": "babel -d lib/ src/",
+    "compile": "babel -d lib/ src/ --ignore '**/test.js'",
     "prepublishOnly": "npm run compile"
   },
   "repository": {


### PR DESCRIPTION
Stop Babel from compiling tests. This way:
- We run each test only twice
- We can see how many tests we actually have
- We stop publishing the tests on `npm`, lowering the package size