### PR TITLE
Polling actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ of the state is being changed.
 - [onConcatenate](./src/effects/onConcatenate/)
 - [onToggle](./src/effects/onToggle/)
 - [onSpreadValue](./src/effects/onSpreadValue/)
+- [onRetry](./src/effects/onRetry/)
 
 We are currently writing some other effects:
 

--- a/src/completers/completeReducer/README.md
+++ b/src/completers/completeReducer/README.md
@@ -2,8 +2,11 @@
 
 This completer can shrink a reducer description if handlers of these reducers are part of an object.  
 
-Receives an object with `primaryActions` that is a string list of action names, and optionally a `override`.  
+Receives an object that describes how you want the reducer to look like for each action.
 For those actions in `primaryActions`, it will add `onLoading`, `onSuccess` and `onFailure` effects for `action.type`, `${action.type}_SUCCESS` and `${action.type}_FAILURE` respectively.  
+For those actions in `pollingActions`, it will add `onLoading`, `onSuccess`, `onFailure` and `onRetry` effects for `action.type`, `${action.type}_SUCCESS`, `${action.type}_FAILURE` and `${action.type}_RETRY` respectively.
+You can use `override` to set a custom reducer for a specific action type.
+
 Example:  
 ```
 const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER'], '@@API');
@@ -54,3 +57,25 @@ const reducer(state = initialState, action) {
 ```
 
 This way, we avoid writing `SUCCESS` and `FAILURE` effects every time.  
+
+
+Here´s an example using `pollingActions`:
+
+```js
+  const reducerDescription = {
+    pollingActions: [actions.POLLING_FETCH]
+  }
+
+  const reducerHandler = completeReducer(reducerDescription);
+  /*
+    {
+      [actions.POLLING_FETCH]: onLoading(),
+      [actions.POLLING_FETCH_SUCCESS]: onSuccess(),
+      [actions.POLLING_FETCH_FAILURE]: onFailure(),
+      [actions.POLLING_FETCH_RETRY]: onRetry()
+    }
+  */
+
+  //now, we create the actual reducer using createReducer
+  const reducer = createReducer(reducerHandler);
+```

--- a/src/completers/completeReducer/index.js
+++ b/src/completers/completeReducer/index.js
@@ -5,6 +5,8 @@ import onFailure from '../../effects/onFailure';
 import onSubscribe from '../../effects/onSubscribe';
 import onUnsubscribe from '../../effects/onUnsubscribe';
 
+import onRetry from '../../effects/onRetry';
+
 import { isStringArray, isValidObject } from '../../utils/typeUtils';
 
 // Given a reducer description, it returns a reducerHandler with all success and failure cases
@@ -12,7 +14,8 @@ function completeReducer(reducerDescription) {
   if (
     !reducerDescription ||
     ((!reducerDescription.primaryActions || !reducerDescription.primaryActions.length) &&
-    (!reducerDescription.modalActions || !reducerDescription.modalActions.length))
+      (!reducerDescription.modalActions || !reducerDescription.modalActions.length) &&
+      (!reducerDescription.pollingActions || !reducerDescription.pollingActions.length))
   ) {
     throw new Error('Reducer description is incomplete, should contain at least an actions field to complete');
   }
@@ -37,6 +40,18 @@ function completeReducer(reducerDescription) {
     reducerDescription.modalActions.forEach(actionName => {
       reducerHandler[`${actionName}_OPEN`] = onSubscribe();
       reducerHandler[`${actionName}_CLOSE`] = onUnsubscribe();
+    });
+  }
+
+  if (reducerDescription.pollingActions) {
+    if (!isStringArray(reducerDescription.pollingActions)) {
+      throw new Error('Polling actions must be a string array');
+    }
+    reducerDescription.pollingActions.forEach(actionName => {
+      reducerHandler[actionName] = onLoading();
+      reducerHandler[`${actionName}_SUCCESS`] = onSuccess();
+      reducerHandler[`${actionName}_FAILURE`] = onFailure();
+      reducerHandler[`${actionName}_RETRY`] = onRetry();
     });
   }
 

--- a/src/completers/completeState/README.md
+++ b/src/completers/completeState/README.md
@@ -1,11 +1,17 @@
 ## completeState - Completer
 
-This completer can extend a state description, helping to reduce its code size.  
+This completer can extend a state description, helping to reduce its code size.
 
-A common pattern is to have a field associated with its Error and its Loading, so this completer adds `Loading` and `Error` extensions to the state for every field that is not an exception.  
+A common pattern is to have a field associated with its Error and its Loading, so this completer adds `Loading` and `Error` extensions to the state for every field that is not an exception.
 
-Receives a state description and a list of target exceptions.  
-Example:  
+Receives a state description and a list of target exceptions. You can also pass an array of the targets you want to treat as polling targets.
+
+The polling targets have some extra properties:
+- `targetCount`: number of retries this request has taken so far
+- `targetIsRetrying`: if the request should be retried, this is set to `true` until either of the `SUCCESS` or `FAILURE` actions are dispatched.
+- `targetTimeoutID`: the `setTimeout` timer id. You pass this id to `clearTimeout` in order to stop retrying.
+
+Example:
 ```
 const initialLongState = {
   thing: null,
@@ -14,6 +20,9 @@ const initialLongState = {
   otherThing: null,
   otherThingLoading: false,
   otherThingError: null,
+  otherThingCount: 0,
+  otherThingIsRetrying: false,
+  otherThingTimeoutID: null,
   anotherThing: null
 };
 
@@ -23,7 +32,7 @@ const initialStateDescription = {
   anotherThing: null
 }
 
-const initialState = completeState(initialStateDescription, ['anotherThing']);
+const initialState = completeState(initialStateDescription, ['anotherThing'], ['otherThing']);
 
 initialState and initialLongState are equivalent.
 ```

--- a/src/completers/completeState/index.js
+++ b/src/completers/completeState/index.js
@@ -1,12 +1,14 @@
 import { isStringArray, isValidObject } from '../../utils/typeUtils';
 
-// Given a defaultState, it populates that state with ${key}Loading and ${key}Error
-function completeState(defaultState, ignoredTargets = []) {
+function completeState(defaultState, ignoredTargets = [], pollingTargets = []) {
   if (!isValidObject(defaultState)) {
     throw new Error('Expected an object as a state to complete.');
   }
   if (!isStringArray(ignoredTargets)) {
     throw new Error('Expected an array of strings as ignored targets');
+  }
+  if (!isStringArray(pollingTargets)) {
+    throw new Error('Expected an array of strings as polling targets');
   }
 
   const completedState = { ...defaultState };
@@ -16,6 +18,13 @@ function completeState(defaultState, ignoredTargets = []) {
       completedState[`${key}Loading`] = false;
       completedState[`${key}Error`] = null;
     });
+
+  pollingTargets.forEach(key => {
+    completedState[`${key}IsRetrying`] = false;
+    completedState[`${key}Count`] = 0;
+    completedState[`${key}TimeoutID`] = null;
+  });
+
   return completedState;
 }
 

--- a/src/completers/completeState/test.js
+++ b/src/completers/completeState/test.js
@@ -34,13 +34,38 @@ describe('completeState', () => {
       otherTarget: 2
     });
   });
+  it('Extends all polling fields', () => {
+    expect(completeState(setUp.state, [], ['otherTarget'])).toEqual({
+      target: 1,
+      targetLoading: false,
+      targetError: null,
+      otherTarget: 2,
+      otherTargetLoading: false,
+      otherTargetError: null,
+      otherTargetIsRetrying: false,
+      otherTargetCount: 0,
+      otherTargetTimeoutID: null
+    });
+  });
   it('Throws if an initial state is not provided', () => {
     expect(() => completeState(null)).toThrow(Error, 'Expected an object as a state to complete.');
   });
   it('Throws if ignored targets is not a list', () => {
-    expect(() => completeState({}, {})).toThrow(Error, 'Expected an array of strings as ignored targets');
+    expect(() => completeState({}, {})).toThrow(
+      Error,
+      'Expected an array of strings as ignored targets'
+    );
   });
   it('Throws if ignored targets is not a pure string array', () => {
-    expect(() => completeState({}, ['1', {}])).toThrow(Error, 'Expected an array of strings as ignored targets');
+    expect(() => completeState({}, ['1', {}])).toThrow(
+      Error,
+      'Expected an array of strings as ignored targets'
+    );
+  });
+  it('Throws if polling targets is not a pure string array', () => {
+    expect(() => completeState({}, [], {})).toThrow(
+      Error,
+      'Expected an array of strings as polling targets'
+    );
   });
 });

--- a/src/completers/completeTypes/README.md
+++ b/src/completers/completeTypes/README.md
@@ -1,11 +1,13 @@
 ## completeTypes - Completer
 
-This completer helps to extends a group of actions including their `SUCCESS` and `FAILURE` cases. It also receives a second parameter that describes which ones are not extended.
+This completer helps to extends a group of actions including their `SUCCESS` and `FAILURE` cases. It also receives a second parameter that describes which ones are not extended. It also receives a third parameter that describes the actions that should be extended for polling.
 
 Examples:
 ```
 const arrTypes = ['AN_ACTION', 'OTHER_ACTION'];
-const completedTypes = completeTypes(arrTypes, ['ANOTHER_ACTION']);
+const ignoredTypes = ['ANOTHER_ACTION']
+const pollingTypes = ['POLLING_ACTION'];
+const completedTypes = completeTypes(arrTypes, ignoredTypes, pollingTypes);
 
 completedTypes is like
 [
@@ -15,6 +17,10 @@ completedTypes is like
   'OTHER_ACTION',
   'OTHER_ACTION_SUCCESS',
   'OTHER_ACTION_FAILURE',
-  'ANOTHER_ACTION',
+  'POLLING_ACTION',
+  'POLLING_ACTION_SUCCESS',
+  'POLLING_ACTION_FAILURE',
+  'POLLING_ACTION_RETRY',
+  'ANOTHER_ACTION'
 ];
 ```

--- a/src/completers/completeTypes/index.js
+++ b/src/completers/completeTypes/index.js
@@ -1,19 +1,26 @@
 import { isStringArray } from '../../utils/typeUtils';
 
-function completeTypes(types, ignoredActions = []) {
+function completeTypes(types, ignoredActions = [], pollingTypes = []) {
   if (!isStringArray(types)) {
     throw new Error('Types must be an array of strings');
   }
   if (!isStringArray(ignoredActions)) {
     throw new Error('Exception cases from actions must be an array of strings');
   }
+  if (!isStringArray(pollingTypes)) {
+    throw new Error('Polling cases from actions must be an array of strings');
+  }
 
   const completedTypes = [];
-  types.forEach(type => {
+
+  const successFailurePatternTypes = [...types, ...pollingTypes];
+  successFailurePatternTypes.forEach(type => {
     completedTypes.push(type);
     completedTypes.push(`${type}_SUCCESS`);
     completedTypes.push(`${type}_FAILURE`);
   });
+
+  pollingTypes.forEach(type => completedTypes.push(`${type}_RETRY`));
 
   return [...completedTypes, ...ignoredActions];
 }

--- a/src/completers/completeTypes/test.js
+++ b/src/completers/completeTypes/test.js
@@ -31,6 +31,28 @@ describe('completeTypes', () => {
   });
   it('Throws if parameters are not string lists', () => {
     expect(() => completeTypes(null)).toThrow(Error, 'Types must be an array of strings');
-    expect(() => completeTypes(['ONE'], null)).toThrow(Error, 'Exception cases from actions must be an array of strings');
+    expect(() => completeTypes(['ONE'], null)).toThrow(
+      Error,
+      'Exception cases from actions must be an array of strings'
+    );
+    expect(() => completeTypes(['ONE'], ['ONE'], null)).toThrow(
+      Error,
+      'Polling cases from actions must be an array of strings'
+    );
+  });
+  it('Completes from an array of polling cases', () => {
+    const arrActions = ['AN_ACTION'];
+    const exceptionCases = ['EXCEPT_ACTION'];
+    const pollingCases = ['POLLING_ACTION'];
+    expect(completeTypes(arrActions, exceptionCases, pollingCases)).toEqual([
+      'AN_ACTION',
+      'AN_ACTION_SUCCESS',
+      'AN_ACTION_FAILURE',
+      'POLLING_ACTION',
+      'POLLING_ACTION_SUCCESS',
+      'POLLING_ACTION_FAILURE',
+      'POLLING_ACTION_RETRY',
+      'EXCEPT_ACTION'
+    ]);
   });
 });

--- a/src/effects/onFailure/README.md
+++ b/src/effects/onFailure/README.md
@@ -7,6 +7,7 @@ This effect is a multi-target effect - It modifies more than one target at the s
 It will:  
   * Put `${action.target}Loading` in `false`  
   * Put `${action.target}Error` with your `action.payload` by default.  
+  * Put `${action.target}IsRetrying` in `false` if `action.isPolling` is truthy
 
 Example:
 ```

--- a/src/effects/onFailure/index.js
+++ b/src/effects/onFailure/index.js
@@ -2,11 +2,17 @@ import { mergeState } from '../../configuration';
 
 // TODO: Add support and validations for multi target actions
 function onFailure(selector = action => action.payload) {
-  return (state, action) =>
-    mergeState(state, {
+  return (state, action) => {
+    const newValues = {
       [`${action.target}Error`]: selector(action, state),
       [`${action.target}Loading`]: false
-    });
+    };
+    if (action.isPolling) {
+      newValues[`${action.target}IsRetrying`] = false;
+    }
+
+    return mergeState(state, newValues);
+  };
 }
 
 export default onFailure;

--- a/src/effects/onFailure/test.js
+++ b/src/effects/onFailure/test.js
@@ -10,12 +10,23 @@ const initialState = {
   targetError: null
 };
 
+const initialPollingState = {
+  target: 'Some content',
+  targetLoading: true,
+  targetError: null,
+  targetIsRetrying: true,
+  targetCount: 3,
+  targetTimeoutID: 3
+};
+
 const setUp = {
-  state: null
+  state: null,
+  pollingState: null
 };
 
 beforeEach(() => {
   setUp.state = Immutable(initialState);
+  setUp.pollingState = Immutable(initialPollingState);
 });
 
 describe('onFailure', () => {
@@ -39,6 +50,25 @@ describe('onFailure', () => {
       target: 'Some content',
       targetLoading: false,
       targetError: 'Error: Oops !'
+    });
+  });
+  it('Sets polling target', () => {
+    const reducer = createReducer(setUp.pollingState, {
+      '@@ACTION/TYPE': onFailure()
+    });
+    const newState = reducer(setUp.pollingState, {
+      type: '@@ACTION/TYPE',
+      target: 'target',
+      payload: 'Boom!',
+      isPolling: true
+    });
+    expect(newState).toEqual({
+      target: 'Some content',
+      targetLoading: false,
+      targetError: 'Boom!',
+      targetIsRetrying: false,
+      targetCount: 3,
+      targetTimeoutID: 3
     });
   });
 });

--- a/src/effects/onRetry/README.md
+++ b/src/effects/onRetry/README.md
@@ -1,0 +1,34 @@
+## onRetry - Effect
+
+This effect is used when the `shouldRetry` function of a polling action returns a truthy value. It sets up the state with the info related to the next try.
+
+This effect is a multi-target effect - It modifies more than one target at the same time.
+
+It will:
+
+- Set `${action.target}IsRetrying` as `true`
+- Set `${action.target}Loading` as `false`
+- Increment `${action.target}Count` by 1
+- Set `${action.target}Error` as `action.payload.error` by default.
+- Set `${action.target}` as `action.payload.interval`
+
+Example:
+
+```
+const selector =
+  (action, state) => action.payload.customError || state.defaultError;
+
+const reducerDescription = {
+  'SUCCESS': onSuccess(),
+  'SUCCESS_CUSTOM': onSuccess(selector)
+};
+```
+
+### Custom selectors
+
+`onRetry` effect receives an optional parameter:
+
+- selector: This function describes how we read the data from the `action`.  
+  `(action, state) => any`  
+  By default, is:  
+  `action => action.payload.error`

--- a/src/effects/onRetry/index.js
+++ b/src/effects/onRetry/index.js
@@ -1,0 +1,15 @@
+import { mergeState } from '../../configuration';
+
+// TODO: Add support and validations for multi target actions
+function onRetry(selector = action => action.payload.error) {
+  return (state, action) =>
+    mergeState(state, {
+      [`${action.target}IsRetrying`]: true,
+      [`${action.target}Loading`]: false,
+      [`${action.target}Count`]: state[`${action.target}Count`] + 1,
+      [`${action.target}Error`]: selector(action, state),
+      [`${action.target}TimeoutID`]: action.payload.interval
+    });
+}
+
+export default onRetry;

--- a/src/effects/onRetry/test.js
+++ b/src/effects/onRetry/test.js
@@ -1,0 +1,61 @@
+import Immutable from 'seamless-immutable';
+
+import createReducer from '../../creators/createReducer';
+
+import onRetry from '.';
+
+const initialState = {
+  target: null,
+  targetLoading: true,
+  targetError: null,
+  targetCount: 0,
+  targetTimeoutID: null,
+  targetIsRetrying: false
+};
+
+const setUp = {
+  state: null
+};
+
+beforeEach(() => {
+  setUp.state = Immutable(initialState);
+});
+
+describe('onRetry', () => {
+  it('Sets correctly target with error and loading', () => {
+    const reducer = createReducer(setUp.state, {
+      '@@ACTION/TYPE': onRetry()
+    });
+    const newState = reducer(setUp.state, {
+      type: '@@ACTION/TYPE',
+      target: 'target',
+      payload: { error: 'Please try again', interval: 1 }
+    });
+    expect(newState).toEqual({
+      target: null,
+      targetLoading: false,
+      targetError: 'Please try again',
+      targetCount: 1,
+      targetTimeoutID: 1,
+      targetIsRetrying: true
+    });
+  });
+  it('Sets conditionally target content based on payload', () => {
+    const reducer = createReducer(setUp.state, {
+      '@@ACTION/TYPE': onRetry(action => action.payload.customError)
+    });
+    const newState = reducer(setUp.state, {
+      type: '@@ACTION/TYPE',
+      target: 'target',
+      payload: { customError: 'Please try again', interval: 1 }
+    });
+    expect(newState).toEqual({
+      target: null,
+      targetLoading: false,
+      targetError: 'Please try again',
+      targetCount: 1,
+      targetTimeoutID: 1,
+      targetIsRetrying: true
+    });
+  });
+});

--- a/src/effects/onSuccess/README.md
+++ b/src/effects/onSuccess/README.md
@@ -8,6 +8,7 @@ It will:
   * Put `${action.target}Loading` in `false`  
   * Put `${action.target}Error` in `null`  
   * Fill `${action.target}` with your `action.payload` by default, or use a selector provided  
+  * Put `${action.target}IsRetrying` in `false` if `action.isPolling` is truthy
 
 Example:  
   ```  

--- a/src/effects/onSuccess/index.js
+++ b/src/effects/onSuccess/index.js
@@ -2,12 +2,18 @@ import { mergeState } from '../../configuration';
 
 // TODO: Add support and validations for multi target actions
 function onSuccess(selector = action => action.payload) {
-  return (state, action) =>
-    mergeState(state, {
+  return (state, action) => {
+    const newValues = {
       [`${action.target}Loading`]: false,
       [`${action.target}`]: selector(action, state),
       [`${action.target}Error`]: null
-    });
+    };
+    if (action.isPolling) {
+      newValues[`${action.target}IsRetrying`] = false;
+    }
+
+    return mergeState(state, newValues);
+  };
 }
 
 export default onSuccess;

--- a/src/effects/onSuccess/test.js
+++ b/src/effects/onSuccess/test.js
@@ -10,12 +10,23 @@ const initialState = {
   targetError: 'Some error'
 };
 
+const initialPollingState = {
+  target: null,
+  targetLoading: true,
+  targetError: 'Some error',
+  targetIsRetrying: true,
+  targetCount: 3,
+  targetTimeoutID: 3
+};
+
 const setUp = {
-  state: null
+  state: null,
+  pollingState: null
 };
 
 beforeEach(() => {
   setUp.state = Immutable(initialState);
+  setUp.pollingState = Immutable(initialPollingState);
 });
 
 describe('onSuccess', () => {
@@ -41,6 +52,25 @@ describe('onSuccess', () => {
       target: 2,
       targetLoading: false,
       targetError: null
+    });
+  });
+  it('Sets polling target', () => {
+    const reducer = createReducer(setUp.pollingState, {
+      '@@ACTION/TYPE': onSuccess()
+    });
+    const newState = reducer(setUp.pollingState, {
+      type: '@@ACTION/TYPE',
+      target: 'target',
+      payload: 'Success Payload',
+      isPolling: true
+    });
+    expect(newState).toEqual({
+      target: 'Success Payload',
+      targetLoading: false,
+      targetError: null,
+      targetIsRetrying: false,
+      targetCount: 3,
+      targetTimeoutID: 3
     });
   });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -25,6 +25,7 @@ import onSubscribe from './effects/onSubscribe';
 import onToggle from './effects/onToggle';
 import onUnsubscribe from './effects/onUnsubscribe';
 import onAppend from './effects/onAppend';
+import onRetry from './effects/onRetry';
 
 import baseThunkAction from './injections/baseThunkAction';
 import composeInjections from './injections/composeInjections';
@@ -67,6 +68,7 @@ exports.onSubscribe = onSubscribe;
 exports.onToggle = onToggle;
 exports.onUnsubscribe = onUnsubscribe;
 exports.onAppend = onAppend;
+exports.onRetry = onRetry;
 
 exports.baseThunkAction = baseThunkAction;
 exports.composeInjections = composeInjections;

--- a/src/injections/pollingAction/index.js
+++ b/src/injections/pollingAction/index.js
@@ -1,0 +1,46 @@
+function pollingAction(action) {
+  const {
+    type,
+    target,
+    service,
+    payload = () => {},
+    successSelector = response => response.data,
+    failureSelector = response => response.problem,
+    timeout = 5000,
+    shouldRetry,
+    determination = response => response.ok
+  } = action;
+  const selector = typeof payload === 'function' ? payload : () => payload;
+
+  return {
+    prebehavior: dispatch => dispatch({ type, target }),
+    apiCall: async getState => service(selector(getState())),
+    determination,
+    success: (dispatch, response) =>
+      dispatch({
+        type: `${type}_SUCCESS`,
+        target,
+        payload: successSelector(response),
+        isPolling: true
+      }),
+    failure: (dispatch, response, state) => {
+      if (shouldRetry(response, state)) {
+        const interval = setTimeout(() => dispatch(action), timeout);
+        dispatch({
+          type: `${type}_RETRY`,
+          target,
+          payload: { interval, error: failureSelector(response) }
+        });
+      } else {
+        dispatch({
+          type: `${type}_FAILURE`,
+          target,
+          payload: failureSelector(response),
+          isPolling: true
+        });
+      }
+    }
+  };
+}
+
+export default pollingAction;

--- a/src/injections/pollingAction/test.js
+++ b/src/injections/pollingAction/test.js
@@ -1,0 +1,150 @@
+import mockStore from '../../utils/asyncActionsUtils';
+import createTypes from '../../creators/createTypes';
+
+let tries = 0;
+
+jest.useFakeTimers();
+
+const MockService = {
+  fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 30, newData: 40 })),
+  fetchFailure: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR' })),
+  fetchFailureForSelector: async () =>
+    new Promise(resolve => resolve({ ok: false, error: 'NEW_CLIENT_ERROR' })),
+  fetchFailureForPolling: async () => {
+    let promise;
+    if (tries == 2) {
+      promise = new Promise(resolve => resolve({ ok: true, status: 200, data: 'OK' }));
+    } else {
+      promise = new Promise(resolve =>
+        resolve({ ok: false, status: 500, problem: 'Still loading' }));
+    }
+    tries++;
+    return promise;
+  }
+};
+
+const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_FETCH'], '@TEST');
+
+describe('pollingAction', () => {
+  it('Uses the default success selector if not specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      shouldRetry: () => false
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: actions.FETCH_SUCCESS,
+        target: 'aTarget',
+        payload: 30,
+        isPolling: true
+      }
+    ]);
+  });
+  it('Uses success selector specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchSomething,
+      successSelector: response => response.newData,
+      shouldRetry: () => false
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: actions.FETCH_SUCCESS,
+        target: 'aTarget',
+        payload: 40,
+        isPolling: true
+      }
+    ]);
+  });
+  it('Uses the default failure selector if not specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailure,
+      shouldRetry: () => false
+    });
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: actions.FETCH_FAILURE,
+        target: 'aTarget',
+        payload: 'CLIENT_ERROR',
+        isPolling: true
+      }
+    ]);
+  });
+  it('Uses failure selector specified via parameters', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailureForSelector,
+      failureSelector: response => response.error,
+      shouldRetry: () => false
+    });
+
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: actions.FETCH_FAILURE,
+        target: 'aTarget',
+        payload: 'NEW_CLIENT_ERROR',
+        isPolling: true
+      }
+    ]);
+  });
+  it('Retries request', async () => {
+    const store = mockStore({});
+    await store.dispatch({
+      type: actions.FETCH,
+      target: 'aTarget',
+      service: MockService.fetchFailureForPolling,
+      shouldRetry: response => !response.ok
+    });
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    jest.runAllTimers();
+
+    // Use setImmediate so the Promise queue moves on and the first setTimeout callback is called
+    await new Promise(resolve => setImmediate(resolve));
+    expect(setTimeout).toHaveBeenCalledTimes(2);
+    jest.runAllTimers();
+
+    await new Promise(resolve => setImmediate(resolve));
+
+    const actionsDispatched = store.getActions();
+    expect(actionsDispatched).toEqual([
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: '@TEST/FETCH_RETRY',
+        target: 'aTarget',
+        payload: { interval: expect.any(Number), error: 'Still loading' }
+      },
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: '@TEST/FETCH_RETRY',
+        target: 'aTarget',
+        payload: { interval: expect.any(Number), error: 'Still loading' }
+      },
+      { type: actions.FETCH, target: 'aTarget' },
+      {
+        type: actions.FETCH_SUCCESS,
+        target: 'aTarget',
+        payload: 'OK',
+        isPolling: true
+      }
+    ]);
+  });
+});

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -4,6 +4,7 @@ import emptyThunkAction from '../injections/emptyThunkAction';
 import singleCallThunkAction from '../injections/singleCallThunkAction';
 import composeInjections from '../injections/composeInjections';
 import mergeInjections from '../injections/mergeInjections';
+import pollingAction from '../injections/pollingAction';
 
 const ensembleInjections = action => {
   let base;
@@ -11,6 +12,8 @@ const ensembleInjections = action => {
     base = externalBaseAction(action);
   } else if (!action.type) {
     base = singleCallThunkAction(action);
+  } else if (action.shouldRetry) {
+    base = pollingAction(action);
   } else {
     base = action.target ? baseThunkAction(action) : emptyThunkAction(action);
   }


### PR DESCRIPTION
## Polling actions
Polling actions! Finally! :tada: 


If you deploy an action that has `shouldRetry`, it will behave as a polling action.

```js
{
type: actions.FETCH,
target: 'target',
service: myService.pollCreationStatus,
shouldRetry: response => response.status === 202,
determination: response => response.status === 201
}
```
It works like this 
![image](https://user-images.githubusercontent.com/7256996/52456772-2e350b00-2b35-11e9-9b62-30557d10d97d.png)

---
The new completed polling state is

- `target`
- `targetLoading`
- `targetError`
- `targetIsRetrying`
- `targetCount`
- `targetTimeoutID`

---
The new completed polling actions are
- `ACTION`
- `ACTION_SUCCESS`
- `ACTION_FAILURE`
- `ACTION_RETRY`

The RETRY action:
- sets `targetIsRetrying` as `true` until either SUCCESS or FAILURE is dispatched
- increments `targetCount` (the number of times the request had to retry)
- sets `targetTimeoutID` with the `setTimeout` ID so you can `clearTimeout` it.
- creates a timer to retry the request

---
Some questionable stuff about this PR:

- `completeTypes` has a third parameter 
```js
completeTypes(['A, 'B'', 'IGNORED', 'POLLING'], ['IGNORED'], ['POLLING'])
```
 - `completeState` has a third parameter
```js
completeState(
 { normalTarget: 1, ignoredTarget: 2, pollingTarget: 3},
 ['ignoredTarget'],
 ['pollingTarget']
)
```

Both of these changes in the API should be discussed here. I only chose that approach because it adheres to what we were using until now (an array for ignored targets, an array for polling targets). I think the best way to do this is to start using an object that has `ignored` and `polling` keys, but I don't want to make that decision by myself. Feel free to leave your opinion on this on the comments!

- In order to test the timer, I had to `await` a `Promise` with `setImmediate`. That's because I am using nested `setTimeout`s. I need it to run all the pending jobs so it actually runs the callback of the second `setTimeout` without having to wait for the timer. I hate this, but it's the only way I could make it work. [Here's some documentation about testing timers using jest](https://jestjs.io/docs/en/timer-mocks)
- I modified the `onSuccess` and `onFailure` effects to reset `targetIsRetrying` if the action has a truthy `isPolling`. I don't know how I feel about this. Maybe we can pass an extra parameter to the effect to indicate that we want to use it with polling actions and remove the `isPolling`.
- The documentation doubtlessly needs more polishing.
---
This is a huge PR and will need as many people reviewing it as possible. Feel free to leave a comment if you think there is room for improvement in the existing code or if you come up with an extra polling-related functionality you would like to add. 😀