### PR TITLE
Add state to withStatusHandling description parameters

### DIFF
--- a/src/injections/withStatusHandling/index.js
+++ b/src/injections/withStatusHandling/index.js
@@ -1,8 +1,8 @@
 function withStatusHandling(statusHandlerDescription) {
   return {
-    statusHandler: (dispatch, response) => (
+    statusHandler: (dispatch, response, state) => (
       statusHandlerDescription[response.status] ?
-        statusHandlerDescription[response.status](dispatch, response) :
+        statusHandlerDescription[response.status](dispatch, response, state) :
         () => true)
   };
 }


### PR DESCRIPTION
Small change. Add `state` to `withStatusHandling` parameters, since the call to the function is:

```js
const shouldContinue = statusHandler(dispatch, response, getState());
```