### PR TITLE
Injectors as arrays

### DIFF
--- a/src/injections/composeInjections/index.js
+++ b/src/injections/composeInjections/index.js
@@ -1,8 +1,4 @@
-import mergeInjections from '../mergeInjections';
-
-function composeInjections(...injections) {
-  const injectionsDescription = mergeInjections(injections);
-
+function composeInjections(injections) {
   const {
     prebehavior = () => {},
     apiCall = () => {},
@@ -13,7 +9,7 @@ function composeInjections(...injections) {
     postFailure = () => {},
     failure = () => {},
     statusHandler = () => true
-  } = injectionsDescription;
+  } = injections;
 
   return async (dispatch, getState) => {
     prebehavior(dispatch);

--- a/src/injections/emptyThunkAction/test.js
+++ b/src/injections/emptyThunkAction/test.js
@@ -15,9 +15,7 @@ describe('emptyThunkAction', () => {
     const store = mockStore({});
     await store.dispatch({ type: actions.FETCH, service: MockService.fetchSomething });
     const actionsDispatched = store.getActions();
-    expect(actionsDispatched).toEqual([
-      { type: actions.FETCH }
-    ]);
+    expect(actionsDispatched).toEqual([{ type: actions.FETCH }]);
   });
   it('Calls the service specified via parameters', async () => {
     const store = mockStore({});
@@ -25,8 +23,10 @@ describe('emptyThunkAction', () => {
       type: actions.FETCH,
       service: MockService.fetchSomething,
       payload: 20,
-      injections: withPostSuccess((dispatch, response) =>
-        dispatch({ type: actions.OTHER_FETCH, payload: response.data }))
+      injections: [
+        withPostSuccess((dispatch, response) =>
+          dispatch({ type: actions.OTHER_FETCH, payload: response.data }))
+      ]
     });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([

--- a/src/injections/mergeInjections/index.js
+++ b/src/injections/mergeInjections/index.js
@@ -1,6 +1,6 @@
 function mergeInjections(injections) {
   if (injections.constructor !== Array) {
-    throw new TypeError('Expected actions injections to be an array');
+    throw new TypeError('Expected action injections to be an array');
   }
   return injections.reduce((a, b) => ({ ...a, ...b }), {});
 }

--- a/src/injections/mergeInjections/index.js
+++ b/src/injections/mergeInjections/index.js
@@ -1,4 +1,7 @@
 function mergeInjections(injections) {
+  if (injections.constructor !== Array) {
+    throw new TypeError('Expected actions injections to be an array');
+  }
   return injections.reduce((a, b) => ({ ...a, ...b }), {});
 }
 

--- a/src/injections/mergeInjections/test.js
+++ b/src/injections/mergeInjections/test.js
@@ -3,7 +3,7 @@ import mergeInjections from './index';
 
 describe('mergeInjections', () => {
   it('Throws error when injections is not an array', () => {
-    expect(() => mergeInjections(withPreFetch(() => {}))).toThrow(new TypeError('Expected actions injections to be an array'));
+    expect(() => mergeInjections(withPreFetch(() => {}))).toThrow(new TypeError('Expected action injections to be an array'));
   });
   it('Merges injections', () => {
     const mergedInjections = mergeInjections([withPreFetch(() => {})]);

--- a/src/injections/mergeInjections/test.js
+++ b/src/injections/mergeInjections/test.js
@@ -1,0 +1,12 @@
+import withPreFetch from '../withPreFetch';
+import mergeInjections from './index';
+
+describe('mergeInjections', () => {
+  it('Throws error when injections is not an array', () => {
+    expect(() => mergeInjections(withPreFetch(() => {}))).toThrow(new TypeError('Expected actions injections to be an array'));
+  });
+  it('Merges injections', () => {
+    const mergedInjections = mergeInjections([withPreFetch(() => {})]);
+    expect(mergedInjections).toEqual({ prebehavior: expect.any(Function) });
+  });
+});

--- a/src/injections/singleCallThunkAction/test.js
+++ b/src/injections/singleCallThunkAction/test.js
@@ -22,12 +22,12 @@ describe('singleCallThunkAction', () => {
     await store.dispatch({
       service: MockService.fetchSomething,
       payload: 20,
-      injections: withPostSuccess((dispatch, response) =>
-        dispatch({ type: actions.OTHER_FETCH, payload: response.data }))
+      injections: [
+        withPostSuccess((dispatch, response) =>
+          dispatch({ type: actions.OTHER_FETCH, payload: response.data }))
+      ]
     });
     const actionsDispatched = store.getActions();
-    expect(actionsDispatched).toEqual([
-      { type: actions.OTHER_FETCH, payload: 21 }
-    ]);
+    expect(actionsDispatched).toEqual([{ type: actions.OTHER_FETCH, payload: 21 }]);
   });
 });

--- a/src/injections/withFailure/test.js
+++ b/src/injections/withFailure/test.js
@@ -6,10 +6,14 @@ import withFailure from '.';
 
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
-  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
+  fetchFailureNotFound: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
 };
 
-const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_ACTION', 'NOT_FOUND'], '@TEST');
+const actions = createTypes(
+  ['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_ACTION', 'NOT_FOUND'],
+  '@TEST'
+);
 
 describe('withFailure', () => {
   it('Handles correctly failure behavior', async () => {
@@ -18,13 +22,13 @@ describe('withFailure', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchSomething,
-      injections: withFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+      injections: [withFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))]
     });
     await store.dispatch({
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchFailureNotFound,
-      injections: withFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+      injections: [withFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))]
     });
     const actionsDispatched = store.getActions();
     // Does not dispatch FAILURE action
@@ -60,7 +64,8 @@ describe('withFailure', () => {
             return false;
           }
         }),
-        withFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))]
+        withFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+      ]
     });
 
     const actionsDispatched = store.getActions();

--- a/src/injections/withFlowDetermination/test.js
+++ b/src/injections/withFlowDetermination/test.js
@@ -5,13 +5,14 @@ import withFlowDetermination from '.';
 
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
-  fetchFailureNotFound: async () => new Promise(resolve =>
-    resolve({
-      ok: false,
-      problem: 'CLIENT_ERROR',
-      status: 404,
-      data: 39
-    }))
+  fetchFailureNotFound: async () =>
+    new Promise(resolve =>
+      resolve({
+        ok: false,
+        problem: 'CLIENT_ERROR',
+        status: 404,
+        data: 39
+      }))
 };
 
 const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_ACTION'], '@TEST');
@@ -23,7 +24,7 @@ describe('withFlowDetermination', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchSomething,
-      injections: withFlowDetermination(response => response.ok)
+      injections: [withFlowDetermination(response => response.ok)]
     });
 
     await store.dispatch({
@@ -37,7 +38,7 @@ describe('withFlowDetermination', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchFailureNotFound,
-      injections: withFlowDetermination(response => response.status === 404)
+      injections: [withFlowDetermination(response => response.status === 404)]
     });
 
     const actionsDispatched = store.getActions();

--- a/src/injections/withPostFailure/test.js
+++ b/src/injections/withPostFailure/test.js
@@ -5,7 +5,8 @@ import withPostFailure from '.';
 
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
-  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
+  fetchFailureNotFound: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
 };
 
 const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_ACTION'], '@TEST');
@@ -17,7 +18,7 @@ describe('withPostFailure', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchFailureNotFound,
-      injections: withPostFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+      injections: [withPostFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))]
     });
 
     const actionsDispatched = store.getActions();
@@ -34,7 +35,7 @@ describe('withPostFailure', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchSomething,
-      injections: withPostFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+      injections: [withPostFailure(dispatch => dispatch({ type: actions.OTHER_ACTION }))]
     });
 
     const actionsDispatched = store.getActions();
@@ -44,4 +45,3 @@ describe('withPostFailure', () => {
     ]);
   });
 });
-

--- a/src/injections/withPostFetch/test.js
+++ b/src/injections/withPostFetch/test.js
@@ -4,8 +4,10 @@ import createTypes from '../../creators/createTypes';
 import withPostFetch from '.';
 
 const MockService = {
-  fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42, ultraSecretData: 'rho' })),
-  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
+  fetchSomething: async () =>
+    new Promise(resolve => resolve({ ok: true, data: 42, ultraSecretData: 'rho' })),
+  fetchFailureNotFound: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
 };
 
 const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'FETCH_LOADING'], '@TEST');
@@ -17,8 +19,10 @@ describe('withPostFetch', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchSomething,
-      injections: withPostFetch((dispatch, response) =>
-        dispatch({ type: actions.FETCH_LOADING, payload: response.ultraSecretData }))
+      injections: [
+        withPostFetch((dispatch, response) =>
+          dispatch({ type: actions.FETCH_LOADING, payload: response.ultraSecretData }))
+      ]
     });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([

--- a/src/injections/withPostSuccess/test.js
+++ b/src/injections/withPostSuccess/test.js
@@ -5,7 +5,8 @@ import withPostSuccess from '.';
 
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
-  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
+  fetchFailureNotFound: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
 };
 
 const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'OTHER_ACTION'], '@TEST');
@@ -17,7 +18,7 @@ describe('withPostSuccess', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchSomething,
-      injections: withPostSuccess(dispatch => dispatch({ type: actions.OTHER_ACTION }))
+      injections: [withPostSuccess(dispatch => dispatch({ type: actions.OTHER_ACTION }))]
     });
 
     const actionsDispatched = store.getActions();

--- a/src/injections/withPreFetch/test.js
+++ b/src/injections/withPreFetch/test.js
@@ -5,7 +5,8 @@ import withPreFetch from '.';
 
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
-  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
+  fetchFailureNotFound: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 }))
 };
 
 const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'FETCH_LOADING'], '@TEST');
@@ -17,7 +18,7 @@ describe('withPreFetch', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchSomething,
-      injections: withPreFetch(dispatch => dispatch({ type: actions.FETCH_LOADING }))
+      injections: [withPreFetch(dispatch => dispatch({ type: actions.FETCH_LOADING }))]
     });
     const actionsDispatched = store.getActions();
     expect(actionsDispatched).toEqual([

--- a/src/injections/withStatusHandling/test.js
+++ b/src/injections/withStatusHandling/test.js
@@ -5,17 +5,22 @@ import withStatusHandling from '.';
 
 const MockService = {
   fetchSomething: async () => new Promise(resolve => resolve({ ok: true, data: 42 })),
-  fetchFailureNotFound: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 })),
-  fetchFailureExpiredToken: async () => new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 422 }))
+  fetchFailureNotFound: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 404 })),
+  fetchFailureExpiredToken: async () =>
+    new Promise(resolve => resolve({ ok: false, problem: 'CLIENT_ERROR', status: 422 }))
 };
 
-const actions = createTypes(['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'NOT_FOUND', 'EXPIRED_TOKEN'], '@TEST');
+const actions = createTypes(
+  ['FETCH', 'FETCH_SUCCESS', 'FETCH_FAILURE', 'NOT_FOUND', 'EXPIRED_TOKEN'],
+  '@TEST'
+);
 
 const customThunkAction = serviceCall => ({
   type: actions.FETCH,
   target: 'aTarget',
   service: serviceCall,
-  injections: withStatusHandling({ 404: dispatch => dispatch({ type: actions.NOT_FOUND }) })
+  injections: [withStatusHandling({ 404: dispatch => dispatch({ type: actions.NOT_FOUND }) })]
 });
 
 describe('withStatusHandling', () => {
@@ -45,11 +50,9 @@ describe('withStatusHandling', () => {
       type: actions.FETCH,
       target: 'aTarget',
       service: MockService.fetchFailureExpiredToken,
-      injections: withStatusHandling({ 422: () => false })
+      injections: [withStatusHandling({ 422: () => false })]
     });
     const actionsDispatched = store.getActions();
-    expect(actionsDispatched).toEqual([
-      { type: actions.FETCH, target: 'aTarget' }
-    ]);
+    expect(actionsDispatched).toEqual([{ type: actions.FETCH, target: 'aTarget' }]);
   });
 });

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -15,16 +15,12 @@ const ensembleInjections = action => {
     base = action.target ? baseThunkAction(action) : emptyThunkAction(action);
   }
   if (!action.injections) return base;
-  const injections = action.injections.constructor === Array
-    ? mergeInjections(action.injections) : action.injections;
+  const injections = mergeInjections(action.injections);
 
   return { ...base, ...injections };
 };
 
-const fetchMiddleware = ({ dispatch }) => next => action => (
-  action.service ?
-    dispatch(composeInjections(ensembleInjections(action))) :
-    next(action)
-);
+const fetchMiddleware = ({ dispatch }) => next => action =>
+  (action.service ? dispatch(composeInjections(ensembleInjections(action))) : next(action));
 
 export default fetchMiddleware;


### PR DESCRIPTION
Only accept arrays for custom injectors. Since all examples were already arrays, there's no need to change the documentation