### PR TITLE
Create types 3.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ jobs:
     parallelism: 1
     shell: /bin/sh
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:11
     steps:
       - checkout
       - run:

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
       "comma-dangle": ["error", "never"],
       "no-console": ["error", {"allow": ["warn", "error"]}],
       "arrow-parens": ["off", { "requireForBlockBody": false }],
-      "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
+      "import/no-extraneous-dependencies": ["error", { "devDependencies": true }],
+      "max-len": "off"
     }
 };

--- a/src/completers/completeTypes/index.js
+++ b/src/completers/completeTypes/index.js
@@ -18,14 +18,9 @@ function completeTypes({ primaryActions, ignoredActions = [], customCompleters =
     if (!isStringArray(actions)) throw new Error('Exception cases from actions must be an array of strings');
     if (typeof completer !== 'function') throw new Error('Completer must be a function');
   });
-
   const primaryTypes = primaryActionsCompleter(primaryActions);
   const ignoredTypes = ignoredActionsCompleter(ignoredActions);
-  const customCompletedTypes = customCompleters.reduce(
-    (customTypes, { actions, completer }) => [...customTypes, ...actions.flatMap(action => completer(action))],
-    []
-  );
-
+  const customCompletedTypes = customCompleters.flatMap(({ actions, completer }) => actions.flatMap(action => completer(action)));
   return [...primaryTypes, ...ignoredTypes, ...customCompletedTypes];
 }
 

--- a/src/completers/completeTypes/index.js
+++ b/src/completers/completeTypes/index.js
@@ -1,12 +1,11 @@
 import { isStringArray } from '../../utils/typeUtils';
 
-const primaryActionsCompleter = primaryActions =>
-  primaryActions.reduce(
-    (completedTypes, type) => [...completedTypes, type, `${type}_SUCCESS`, `${type}_FAILURE`],
-    []
-  );
+export const primaryActionsCompleter = primaryActions => primaryActions.reduce(
+  (completedTypes, type) => [...completedTypes, type, `${type}_SUCCESS`, `${type}_FAILURE`],
+  []
+);
 
-const ignoresActionsCompleter = ignoredActions => ignoredActions || [];
+export const ignoredActionsCompleter = ignoredActions => ignoredActions || [];
 
 function completeTypes({ primaryActions, ignoredActions = [], customCompleters = [] }) {
   if (!isStringArray(primaryActions)) {
@@ -21,9 +20,9 @@ function completeTypes({ primaryActions, ignoredActions = [], customCompleters =
   });
 
   const primaryTypes = primaryActionsCompleter(primaryActions);
-  const ignoredTypes = ignoresActionsCompleter(ignoredActions);
+  const ignoredTypes = ignoredActionsCompleter(ignoredActions);
   const customCompletedTypes = customCompleters.reduce(
-    (customTypes, { actions, completer }) => completer(actions),
+    (customTypes, { actions, completer }) => [...customTypes, ...actions.flatMap(action => completer(action))],
     []
   );
 

--- a/src/completers/completeTypes/index.js
+++ b/src/completers/completeTypes/index.js
@@ -1,21 +1,33 @@
 import { isStringArray } from '../../utils/typeUtils';
 
-function completeTypes(types, ignoredActions = []) {
-  if (!isStringArray(types)) {
-    throw new Error('Types must be an array of strings');
+const primaryActionsCompleter = primaryActions =>
+  primaryActions.reduce(
+    (completedTypes, type) => [...completedTypes, type, `${type}_SUCCESS`, `${type}_FAILURE`],
+    []
+  );
+
+const ignoresActionsCompleter = ignoredActions => ignoredActions || [];
+
+function completeTypes({ primaryActions, ignoredActions = [], customCompleters = [] }) {
+  if (!isStringArray(primaryActions)) {
+    throw new Error('Primary actions must be an array of strings');
   }
   if (!isStringArray(ignoredActions)) {
-    throw new Error('Exception cases from actions must be an array of strings');
+    throw new Error('Ignored actions must be an array of strings');
   }
-
-  const completedTypes = [];
-  types.forEach(type => {
-    completedTypes.push(type);
-    completedTypes.push(`${type}_SUCCESS`);
-    completedTypes.push(`${type}_FAILURE`);
+  customCompleters.forEach(({ actions, completer }) => {
+    if (!isStringArray(actions)) throw new Error('Exception cases from actions must be an array of strings');
+    if (typeof completer !== 'function') throw new Error('Completer must be a function');
   });
 
-  return [...completedTypes, ...ignoredActions];
+  const primaryTypes = primaryActionsCompleter(primaryActions);
+  const ignoredTypes = ignoresActionsCompleter(ignoredActions);
+  const customCompletedTypes = customCompleters.reduce(
+    (customTypes, { actions, completer }) => completer(actions),
+    []
+  );
+
+  return [...primaryTypes, ...ignoredTypes, ...customCompletedTypes];
 }
 
 export default completeTypes;

--- a/src/completers/completeTypes/test.js
+++ b/src/completers/completeTypes/test.js
@@ -3,11 +3,15 @@ import completeTypes from '.';
 describe('completeTypes', () => {
   it('Completes from an array\'s element', () => {
     const arrTypes = ['AN_ACTION'];
-    expect(completeTypes(arrTypes)).toEqual(['AN_ACTION', 'AN_ACTION_SUCCESS', 'AN_ACTION_FAILURE']);
+    expect(completeTypes({ primaryActions: arrTypes })).toEqual(['AN_ACTION', 'AN_ACTION_SUCCESS', 'AN_ACTION_FAILURE']);
+  });
+  it('Must have primary actions', () => {
+    const arrTypes = ['AN_ACTION'];
+    expect(completeTypes({ primaryActions: arrTypes })).toEqual(['AN_ACTION', 'AN_ACTION_SUCCESS', 'AN_ACTION_FAILURE']);
   });
   it('Completes from an array of multiple elements', () => {
     const arrTypes = ['AN_ACTION', 'OTHER_ACTION', 'ANOTHER_ACTION'];
-    expect(completeTypes(arrTypes)).toEqual([
+    expect(completeTypes({ primaryActions: arrTypes })).toEqual([
       'AN_ACTION',
       'AN_ACTION_SUCCESS',
       'AN_ACTION_FAILURE',
@@ -22,15 +26,30 @@ describe('completeTypes', () => {
   it('Does not complete from exception cases', () => {
     const arrActions = ['AN_ACTION'];
     const exceptionCases = ['EXCEPT_ACTION'];
-    expect(completeTypes(arrActions, exceptionCases)).toEqual([
+    expect(completeTypes({ primaryActions: arrActions, ignoredActions: exceptionCases })).toEqual([
       'AN_ACTION',
       'AN_ACTION_SUCCESS',
       'AN_ACTION_FAILURE',
       'EXCEPT_ACTION'
     ]);
   });
-  it('Throws if parameters are not string lists', () => {
-    expect(() => completeTypes(null)).toThrow(new Error('Types must be an array of strings'));
-    expect(() => completeTypes(['ONE'], null)).toThrow(new Error('Exception cases from actions must be an array of strings'));
+  it('Throws if parameters are not the expected ones', () => {
+    expect(() => completeTypes({ primaryActiosn: null })).toThrow(new Error('Primary actions must be an array of strings'));
+    expect(() => completeTypes({ primaryActions: ['ONE'], ignoredActions: null })).toThrow(new Error('Ignored actions must be an array of strings'));
+    expect(() => completeTypes({
+      primaryActions: ['ONE'],
+      ignoredActions: ['TWO'],
+      customCompleters: [{
+        actions: null
+      }]
+    })).toThrow(new Error('Exception cases from actions must be an array of strings'));
+    expect(() => completeTypes({
+      primaryActions: ['ONE'],
+      ignoredActions: ['TWO'],
+      customCompleters: [{
+        actions: ['THREE'],
+        completer: null
+      }]
+    })).toThrow(new Error('Completer must be a function'));
   });
 });

--- a/src/completers/completeTypes/test.js
+++ b/src/completers/completeTypes/test.js
@@ -33,6 +33,19 @@ describe('completeTypes', () => {
       'EXCEPT_ACTION'
     ]);
   });
+  it('Custom completers completes all types passed', () => {
+    const primaryActions = [];
+    const ignoredActions = [];
+    const completer = type => [type, `${type}_SUCCESS`, `${type}_FAILURE`];
+    const customCompleters = [
+      { completer, actions: ['CUSTOM_ACTION'] }
+    ];
+    expect(completeTypes({ primaryActions, ignoredActions, customCompleters })).toEqual([
+      'CUSTOM_ACTION',
+      'CUSTOM_ACTION_SUCCESS',
+      'CUSTOM_ACTION_FAILURE'
+    ]);
+  });
   it('Throws if parameters are not the expected ones', () => {
     expect(() => completeTypes({ primaryActiosn: null })).toThrow(new Error('Primary actions must be an array of strings'));
     expect(() => completeTypes({ primaryActions: ['ONE'], ignoredActions: null })).toThrow(new Error('Ignored actions must be an array of strings'));


### PR DESCRIPTION
## Summary

This Pull Request is the first step of the new API of Redux-Recompose. Here we are changing the way `createTypes`, now this method will receive an object instead of two arrays. This object will receive three keys: `primaryActions`, `ignoredActions` and `customCompleters`. 
The primary actions and ignored actions will have the same behaviour in the previous API has. The custom completers are the brand new things in this API, it would be an array of objects with two keys: completer and actions. The completer is a function that receives a type (as an string) and returns an array of the completed actions. And actions are an array of strings that would be the entrance of the completer functions.

## Example

```js
completeTypes({
  primaryActions: ["ACTION"],
  ignoredActions: ["ACTION_2"],
  customComplete: [ { completer: funcion, actions: ["ACTION_3"] }, { completer: funcion, actions: ["ACTION_3"] }  ]
})