### PR TITLE
Change injections third parameter

### DIFF
--- a/src/injections/composeInjections/index.js
+++ b/src/injections/composeInjections/index.js
@@ -20,13 +20,13 @@ function composeInjections(...injections) {
     const response = await apiCall(getState);
     postBehavior(dispatch, response);
     if (determination(response)) {
-      const shouldContinue = success(dispatch, response, getState());
-      if (shouldContinue) postSuccess(dispatch, response, getState());
+      const shouldContinue = success(dispatch, response, getState);
+      if (shouldContinue) postSuccess(dispatch, response, getState);
     } else {
-      const shouldContinue = statusHandler(dispatch, response, getState());
+      const shouldContinue = statusHandler(dispatch, response, getState);
       if (shouldContinue) {
-        failure(dispatch, response, getState());
-        postFailure(dispatch, response, getState());
+        failure(dispatch, response, getState);
+        postFailure(dispatch, response, getState);
       }
     }
   };

--- a/src/injections/withFailure/README.md
+++ b/src/injections/withFailure/README.md
@@ -15,7 +15,7 @@ Example:
       service: someService,
       payload: data,
       injections: [
-        withFailure((dispatch, response, state) => {
+        withFailure((dispatch, response, getState) => {
           /* insert here whatever logic
           * you want to override the onFailure
           * effect with. You can dispatch actions

--- a/src/injections/withPostFailure/README.md
+++ b/src/injections/withPostFailure/README.md
@@ -14,7 +14,7 @@ Example:
       service: someService,
       payload: data,
       injections: [
-        withPostFailure((dispatch, response, state) => {
+        withPostFailure((dispatch, response, getState) => {
           /* insert here whatever logic
            * you want to execute after a failed service call.
            * This is particularly userful to dispatch side efects for failed service calls.

--- a/src/injections/withPostSuccess/README.md
+++ b/src/injections/withPostSuccess/README.md
@@ -14,7 +14,7 @@ Example:
       service: someService,
       payload: data,
       injections: [
-        withPostSuccess((dispatch, response, state) => {
+        withPostSuccess((dispatch, response, getState) => {
           /* insert here whatever logic
            * you want to execute after service call and SUCCCESSFUL pattern.
            * This is particularly userful to dispatch side efects or actions to different targets

--- a/src/injections/withStatusHandling/README.md
+++ b/src/injections/withStatusHandling/README.md
@@ -16,8 +16,8 @@ Example:
       payload: data,
       injections: [
         withStatusHandling({
-          401: (dispatch, response, state) => handle401(state, dispatch, response),
-          404: (dispatch, response, state) => handle404(response, dispatch, state)
+          401: (dispatch, response, getState) => handle401(getState, dispatch, response),
+          404: (dispatch, response, getState) => handle404(response, dispatch, getState)
         })
       ]
     })

--- a/src/injections/withSuccess/README.md
+++ b/src/injections/withSuccess/README.md
@@ -15,7 +15,7 @@ Example:
       service: someService,
       payload: data,
       injections: [
-        withSuccess((dispatch, response) => {
+        withSuccess((dispatch, response, getState) => {
           /* insert here whatever logic
           * you want to override the onSuccess
           * effect with. You can dispatch actions


### PR DESCRIPTION
## Summary

This Pull Request is a breaking change with the previous version of Redux-Recompose. Here we are changing how injections are being used. This change change only these injections: 
`withSuccess`, `withFailure`, `withPostSuccess`, `withPostFailure` and `withStatusHandling`. Now in all this injectors we will receive as third parameter the `getState` function instead the `state` himself. 

## Example

```js
const actionCreators = {
    someAction: data => ({
      type: actionType,
      target: someTarget,
      service: someService,
      payload: data,
      injections: [
        withSuccess((dispatch, response, getState) => {
          const { auth: { user } } = getState();
          dispatch({
            type: someOtherAction,
            target: someTarget,
            payload: user
          });
        })
      ]
    })
  };