### PR TITLE
Multi Environment actions (Scoped Actions)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -42,6 +42,8 @@ import withSuccess from './injections/withSuccess';
 
 import fetchMiddleware from './middlewares/fetch';
 
+import decorateWithScope from './utils/decorateWithScope';
+
 exports.configureMergeState = configureMergeState;
 
 exports.wrapCombineReducers = wrapCombineReducers;
@@ -86,3 +88,5 @@ exports.withStatusHandling = withStatusHandling;
 exports.withSuccess = withSuccess;
 
 exports.fetchMiddleware = fetchMiddleware;
+
+exports.decorateWithScope = decorateWithScope;

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -21,9 +21,16 @@ const ensembleInjections = action => {
   return { ...base, ...injections };
 };
 
-const fetchMiddleware = ({ dispatch }) => next => action => (
+const shouldExecuteAction = (currentEnv, scopes) =>
+  Array.isArray(scopes) &&
+  scopes.some(scope => Object.entries(scope).every(([key, value]) => currentEnv[key] === value));
+
+const scopeMiddleware =  (currentEnv, action) =>
+  action.scopes ? shouldExecuteAction(currentEnv, action.scopes) && dispatch(composeInjections(ensembleInjections(action))) : dispatch(composeInjections(ensembleInjections(action)));
+
+const fetchMiddleware = currentEnv => () => next => action => (
   action.service ?
-    dispatch(composeInjections(ensembleInjections(action))) :
+    scopeMiddleware(currentEnv, action) :
     next(action)
 );
 

--- a/src/middlewares/fetch.js
+++ b/src/middlewares/fetch.js
@@ -25,12 +25,15 @@ const shouldExecuteAction = (currentEnv, scopes) =>
   Array.isArray(scopes) &&
   scopes.some(scope => Object.entries(scope).every(([key, value]) => currentEnv[key] === value));
 
-const scopeMiddleware =  (currentEnv, action) =>
-  action.scopes ? shouldExecuteAction(currentEnv, action.scopes) && dispatch(composeInjections(ensembleInjections(action))) : dispatch(composeInjections(ensembleInjections(action)));
+const scopeMiddleware = (currentEnv, action, dispatch) =>
+  (action.scopes
+    ? shouldExecuteAction(currentEnv, action.scopes)
+    && dispatch(composeInjections(ensembleInjections(action)))
+    : dispatch(composeInjections(ensembleInjections(action))));
 
-const fetchMiddleware = currentEnv => () => next => action => (
+const fetchMiddleware = currentEnv => dispatch => next => action => (
   action.service ?
-    scopeMiddleware(currentEnv, action) :
+    scopeMiddleware(currentEnv, action, dispatch) :
     next(action)
 );
 

--- a/src/utils/decorateWithScope.js
+++ b/src/utils/decorateWithScope.js
@@ -1,0 +1,18 @@
+export const decorateWithScope = (scopes, actionCreators) => {
+    const asyncRegex = /async/;
+    return Object.entries(actionCreators).reduce((result, [actionName, actionCreator]) => {
+      if (asyncRegex.test(actionCreator.toString())) {
+        result[actionName] = (...args) => {
+          const asyncAction = actionCreator(...args);
+          asyncAction.scopes = scopes[actionName];
+          return asyncAction;
+        };
+        return result;
+      }
+      result[actionName] = (...args) => ({
+        ...actionCreator(...args),
+        scopes: scopes[actionName]
+      });
+      return result;
+    }, {});
+  };

--- a/src/utils/decorateWithScope.js
+++ b/src/utils/decorateWithScope.js
@@ -1,18 +1,22 @@
-export const decorateWithScope = (scopes, actionCreators) => {
-    const asyncRegex = /async/;
-    return Object.entries(actionCreators).reduce((result, [actionName, actionCreator]) => {
-      if (asyncRegex.test(actionCreator.toString())) {
-        result[actionName] = (...args) => {
-          const asyncAction = actionCreator(...args);
-          asyncAction.scopes = scopes[actionName];
-          return asyncAction;
-        };
-        return result;
-      }
-      result[actionName] = (...args) => ({
-        ...actionCreator(...args),
-        scopes: scopes[actionName]
-      });
+const decorateWithScope = (scopes, actionCreators) => {
+  const asyncRegex = /async/;
+  return Object.entries(actionCreators).reduce((result, [actionName, actionCreator]) => {
+    if (asyncRegex.test(actionCreator.toString())) {
+      // eslint-disable-next-line no-param-reassign
+      result[actionName] = (...args) => {
+        const asyncAction = actionCreator(...args);
+        asyncAction.scopes = scopes[actionName];
+        return asyncAction;
+      };
       return result;
-    }, {});
-  };
+    }
+    // eslint-disable-next-line no-param-reassign
+    result[actionName] = (...args) => ({
+      ...actionCreator(...args),
+      scopes: scopes[actionName]
+    });
+    return result;
+  }, {});
+};
+
+export default decorateWithScope;


### PR DESCRIPTION
## Summary

- Made a `decorateWithScope` method to be able to add scopes to async actions that do not use redux-recompose. It also works if you want to keep your scopes in another file.
- Modified `fetchMiddleware` to take the current environment as an argument. 
- Added `shouldExecuteAction` to validate actions' scopes.

## Details

I've been working on a way to handle actions/requests triggered by different environments. I took the project I've been working on as pilot test since it has to deal with several environments

### The problem with the current approach:

It only targets one level. The current repository has to deal with 3 levels: 

![image](https://user-images.githubusercontent.com/36488701/70831179-9d703100-1dd0-11ea-9f92-53b924855726.png)

If we look closer at it, we'll get that we have to deal with 16 possible environments. With that in mind, if we wanted to target each option we would have to have a really nested dictionary in every component to map every action to their corresponding environment.

### The proposal: 

To solve this I thought that every action could have a scope that could be flexible enough to target an entire level, instead of having to specify every option and that could also be specific enough when needed. Then, I could match it against the app's current environment and see if the scope applies. If true the action will be triggered. 

Current Env

```js
export const CURRENT_ENVIRONMENT = {
  [ENVIRONMENTS.APP]: APP_TYPE,
  [ENVIRONMENTS.CLIENT]: CLIENT_TYPE,
  [ENVIRONMENTS.COUNTRY]: CURRENT_COUNTRY
};
```
Scoped Action (Example)

```js
initializeStates: filter => ({
    type: actions.GET_STATES,
    target: TARGETS.states,
    service: AddressService.getStates,
    scopes: [
      { [ENVIRONMENTS.APP]: APP_1 },
      { [ENVIRONMENTS.APP]: APP_2, [ENVIRONMENTS.COUNTRY]: COUNTRIES.CL }
    ],
    payload: filter
  }),
```

The above scoped action will apply to the entire APP 1 context (8 environments) 'cause it will match only against the context of our current environment. If true, it will triggered the action across both vendor & seller and all countries. Additionally, since we have 2 scopes it will also apply to the APP 2 node. The second scope will affect 2 environments: `APP2/CLIENT1/CHILE` & `APP2/CLIENT2/CHILE` 'cause, then again, it will match only against the country and the context of our current environment. 

How do we achieve this ? 

We use a method to check the scope

```js
const shouldExecuteAction = (currentEnv, scopes) =>
  Array.isArray(scopes) &&
  scopes.some(scope => Object.entries(scope).every(([key, value]) => currentEnv[key] === value));
```

Finally we just need to check for every action triggered, so we use a middleware for this and create a scope description to decorate our actions (since we are going to have both traditional async actions and redux recompose actions)

## Example

The main idea is to go from this: 

```js
componentDidMount() {
  const { getStates, getCommunes, getDepartments } = this.props;
  if (isFromPeru) {
    getStates();
  }
  else if (isFromChile) {
    getCommunes();
  }
  else if (isFromColombia) {
    getDepartments();
  }
}
````

To this: 

```js
componentDidMount() {
  const { getStates, getCommunes, getDepartments } = this.props;
    getStates();
    getCommunes();
    getDepartments();
}
````
